### PR TITLE
Refactor auction house and city options methods

### DIFF
--- a/site/app/components/PaginatedTable.js
+++ b/site/app/components/PaginatedTable.js
@@ -143,17 +143,20 @@ export default {
     },
     auctionHouseOptions() {
       return [
-        ...new Map(
-          this.rows.map(row => [
-            row['Auction House'].trim(),
-            row['Auction House']
-          ])
-        ).values()
+        ...new Set(
+          this.rows.map(row => {
+            return row['Auction House'].trim();
+          })
+        )
       ];
     },
     cityOptions() {
       return [
-        ...new Map(this.rows.map(row => [row.City.trim(), row.City])).values()
+        ...new Set(
+          this.rows.map(row => {
+            return row.City.trim();
+          })
+        )
       ].filter(c => c !== '');
     }
   },


### PR DESCRIPTION
Use `Set`, rather than `Map`, to reduce the complexity of creating key-value pairs, only to take the values.