### PR TITLE
static_tables#58: Filter component events also include the field id

### DIFF
--- a/app/components/PaginatedTable.js
+++ b/app/components/PaginatedTable.js
@@ -117,29 +117,29 @@ export default {
     dateConfig() {
       return this.dataFilters.find(filter => filter.id === 'date');
     },
-    handleDateChange(value) {
-      this.filterSet.setValue('date', value);
+    handleDateChange(change) {
+      this.filterSet.setValue(change.field, change.value);
       this.filterRows();
     },
     nameConfig() {
       return this.dataFilters.find(filter => filter.id === 'name');
     },
-    handleNameChange(value) {
-      this.filterSet.setValue('name', value);
+    handleNameChange(change) {
+      this.filterSet.setValue(change.field, change.value);
       this.filterRows();
     },
     auctionHouseConfig() {
       return this.dataFilters.find(filter => filter.id === 'auction-house');
     },
-    handleAuctionHouseChange(value) {
-      this.filterSet.setValue('auction-house', value);
+    handleAuctionHouseChange(change) {
+      this.filterSet.setValue(change.field, change.value);
       this.filterRows();
     },
     cityConfig() {
       return this.dataFilters.find(filter => filter.id === 'city');
     },
-    handleCityChange(value) {
-      this.filterSet.setValue('city', value);
+    handleCityChange(change) {
+      this.filterSet.setValue(change.field, change.value);
       this.filterRows();
     },
     setData(rows) {

--- a/app/components/SelectFilter.js
+++ b/app/components/SelectFilter.js
@@ -23,7 +23,10 @@ export default {
   },
   methods: {
     handleChange(event) {
-      this.$emit('selected', event.target.value);
+      this.$emit('selected', {
+        field: this.config.id,
+        value: event.target.value
+      });
     }
   }
 };

--- a/app/components/SelectFilter.test.js
+++ b/app/components/SelectFilter.test.js
@@ -10,7 +10,7 @@ describe('SelectFilter', () => {
 
     expect(wrapper.get('label').text()).toEqual('City');
   });
-  test('it uses the id to associate the select and the input', () => {
+  test('it uses the id to associate the label and the select', () => {
     const wrapper = mount(SelectFilter, {
       props: { config: { name: 'City', id: 'my-city' } }
     });
@@ -48,6 +48,7 @@ describe('SelectFilter', () => {
     const wrapper = mount(SelectFilter, {
       props: {
         config: {
+          id: 'city',
           options_generator: () => ['Option 1', 'Option 2']
         },
         rows: []
@@ -57,6 +58,8 @@ describe('SelectFilter', () => {
     wrapper.get('select').setValue('Option 2');
 
     expect(wrapper.emitted()['selected'].length).toEqual(1);
-    expect(wrapper.emitted()['selected'][0]).toEqual(['Option 2']);
+    expect(wrapper.emitted()['selected'][0]).toEqual([
+      { field: 'city', value: 'Option 2' }
+    ]);
   });
 });

--- a/app/components/TextFilter.js
+++ b/app/components/TextFilter.js
@@ -8,7 +8,10 @@ export default {
   emits: ['changed'],
   methods: {
     handleInput(event) {
-      this.$emit('changed', event.target.value);
+      this.$emit('changed', {
+        field: this.config.id,
+        value: event.target.value
+      });
     }
   }
 };

--- a/app/components/TextFilter.test.js
+++ b/app/components/TextFilter.test.js
@@ -30,11 +30,13 @@ describe('TextFilter', () => {
   });
 
   test('it emits an event when the value changes', () => {
-    const wrapper = mount(TextFilter, { props: { config: {} } });
+    const wrapper = mount(TextFilter, { props: { config: { id: 'title' } } });
 
     wrapper.get('input').setValue('bronze');
 
     expect(wrapper.emitted()['changed'].length).toEqual(1);
-    expect(wrapper.emitted()['changed'][0]).toEqual(['bronze']);
+    expect(wrapper.emitted()['changed'][0]).toEqual([
+      { field: 'title', value: 'bronze' }
+    ]);
   });
 });


### PR DESCRIPTION
This is an incremental step toward auto-generating filters from the configuration file, since it allows us to remove a few hard-coded filter ids from the PaginatedTable component.

helps with #58 