### PR TITLE
#86: Resolve Vue warning about extraneous non-props attributes

### DIFF
--- a/app/components/PaginatedTable.js
+++ b/app/components/PaginatedTable.js
@@ -114,9 +114,6 @@ export default {
     totalEntries() {
       return this.filteredRows.length;
     },
-    filterComponent(type) {
-      return type === 'text' ? TextFilter : SelectFilter;
-    },
     handleFilterChange(change) {
       this.filterSet.setValue(change.field, change.value);
       this.filterRows();
@@ -138,7 +135,8 @@ export default {
         <form>
           <div class="row">
             <div class="col" v-for="filter in dataFilters">
-              <component :is="filterComponent(filter.type)" :config="filter" @filterChange="handleFilterChange" :rows="rows"></component>
+              <TextFilter v-if="filter.type === 'text'" :config="filter" @filterChange="handleFilterChange"></TextFilter>
+              <SelectFilter v-else :config="filter" @filterChange="handleFilterChange" :rows="rows"></SelectFilter>
             </div>
           </div>
           <div class="row">


### PR DESCRIPTION
Previously, we used a dynamic component for the filter, and sent it the same props, whether or not it could use them.  TextSelect has no need of the rows prop, so Vue gave us this warning.

Using v-if and v-else has the same effect as the dynamic component, gives us the opportunity to pass different props to different components, and is probably more readable anyway.

Closes #86