### PR TITLE
issue #91: Use window.location.path, rather than window.location.hash for routing

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -8,8 +8,9 @@ import DataFilters from './configs/DataFilters.js';
 import marquandBannerUrl from './assets/images/marquand-banner_0.jpg';
 import { sortByDate } from './utilities/SortingUtilities.js';
 
+// prettier-ignore
 const routes = {
-  marquand: 'marquand',
+  'marquand': 'marquand',
   'faculty-and-professional-staff-index': 'faculty_and_staff'
 };
 

--- a/app/App.js
+++ b/app/App.js
@@ -9,8 +9,8 @@ import marquandBannerUrl from './assets/images/marquand-banner_0.jpg';
 import { sortByDate } from './utilities/SortingUtilities.js';
 
 const routes = {
-  '/marquand': 'marquand',
-  '/faculty-and-professional-staff-index': 'faculty_and_staff'
+  marquand: 'marquand',
+  'faculty-and-professional-staff-index': 'faculty_and_staff'
 };
 
 export default {
@@ -22,31 +22,27 @@ export default {
   },
   data() {
     return {
-      currentPath: window.location.hash,
       sorterMethod: sortByDate,
       dataUrl: DataSources.marquand,
       dataColumns: DataColumns.marquand,
       dataTableDescription: DataMetadata.marquand.description,
       dataTableTitle: DataMetadata.marquand.table_title,
       dataFilters: DataFilters.marquand,
-      // dataPageTitle: DataMetadata.marquand.page_title,
       dataHeaderTitle: DataMetadata.marquand.header_title,
       bannerUrl: marquandBannerUrl
     };
   },
   computed: {
     currentConfig() {
-      console.log(`Current path: ${this.currentPath}`);
-      return DataMetadata[routes[this.currentPath.slice(1) || '/marquand']];
+      return DataMetadata[this.desiredRoute];
     },
     dataPageTitle() {
       return this.currentConfig.page_title;
+    },
+    desiredRoute() {
+      const routePath = window.location.pathname.split('/').pop();
+      return routes[routePath] || routes['marquand'];
     }
-  },
-  mounted() {
-    window.addEventListener('hashchange', () => {
-      this.currentPath = window.location.hash;
-    });
   },
   template: `
     <Header :title="dataHeaderTitle"></Header>

--- a/app/App.test.js
+++ b/app/App.test.js
@@ -21,7 +21,7 @@ describe('App', () => {
     test('changing page title by url', () => {
       Object.defineProperty(window, 'location', {
         value: new URL(
-          'https://library.princeton.edu#/faculty-and-professional-staff-index'
+          'https://library.princeton.edu/static_tables/faculty-and-professional-staff-index'
         )
       });
       wrapper = mount(App);


### PR DESCRIPTION
This has the benefits of:
  * cleaner URLs
  * We can still add a Skip to Main content later, without interfering with hash-based routing
  * Compatible with the nginx try_files directive

closes #91