### PR TITLE
Allow Select Filters to have a different label vs. value

### DIFF
--- a/app/components/SelectFilter.js
+++ b/app/components/SelectFilter.js
@@ -7,7 +7,7 @@ export default {
               @change="handleChange"
               class="form-select">
           <option selected value="">- Any -</option>
-          <option v-for="option in options">{{option}}</option>
+          <option v-for="option in options" :value="option[0]">{{option[1]}}</option>
       </select>
       `,
   props: ['config', 'rows'],

--- a/app/components/SelectFilter.test.js
+++ b/app/components/SelectFilter.test.js
@@ -31,7 +31,9 @@ describe('SelectFilter', () => {
       props: {
         config: {
           options_generator: rows => {
-            return rows.filter(row => row.startsWith('c'));
+            return rows
+              .filter(row => row.startsWith('c'))
+              .map(value => [value, value]);
           }
         },
         rows: ['cat', 'dog', 'cheetah']
@@ -49,17 +51,20 @@ describe('SelectFilter', () => {
       props: {
         config: {
           id: 'city',
-          options_generator: () => ['Option 1', 'Option 2']
+          options_generator: () => [
+            ['opt1', 'Option 1'],
+            ['opt2', 'Option 2']
+          ]
         },
         rows: []
       }
     });
 
-    wrapper.get('select').setValue('Option 2');
+    wrapper.get('select').setValue('opt2');
 
     expect(wrapper.emitted()['filterChange'].length).toEqual(1);
     expect(wrapper.emitted()['filterChange'][0]).toEqual([
-      { field: 'city', value: 'Option 2' }
+      { field: 'city', value: 'opt2' }
     ]);
   });
 });

--- a/app/configs/Marquand.js
+++ b/app/configs/Marquand.js
@@ -35,7 +35,7 @@ export default {
               return row['Auction House'].trim();
             })
           )
-        ];
+        ].map(value => [value, value]);
       }
     },
     {
@@ -51,7 +51,9 @@ export default {
               return row.City.trim();
             })
           )
-        ].filter(c => c !== '');
+        ]
+          .filter(c => c !== '')
+          .map(value => [value, value]);
       }
     }
   ],


### PR DESCRIPTION
Before this commit, options_generator arrow functions generated arrays of strings.  However, sometimes (as with the Faculty and Professional Staff index), we will need the Select Filter to display a different value than the actual value to filter on.  So this commit makes the options_generator return an array of 2-element arrays, representing the filter value and the display value.

Helps with #34