### PR TITLE
[#110] In HTML 5, scope attributes may only be used on table header elements

### DIFF
--- a/app/components/Table.js
+++ b/app/components/Table.js
@@ -13,7 +13,7 @@ export default {
       </thead>
       <tbody>
         <tr v-for="row in rows">
-          <td v-for="column in columns" scope="row">{{row[column[1]]}}</td>
+          <td v-for="column in columns">{{row[column[1]]}}</td>
         </tr>
       </tbody>
     </table>`


### PR DESCRIPTION
closes #110 