### PR TITLE
Change route to marquand-catalogs, not marquand

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -10,7 +10,7 @@ import TrusteeIndex from './configs/TrusteeIndex.js';
 
 // prettier-ignore
 const routes = {
-  'marquand': 'marquand',
+  'marquand-catalogs': 'marquand',
   'faculty-and-professional-staff-index': 'faculty_and_staff',
   'princeton-university-graduate-alumni-index': 'graduate_alumni_index',
   'honorary-degree-index': 'honorary_degree',


### PR DESCRIPTION
- on the library site, ./marquand is the main marquand library page, not the catalog page, and we should maintain that

Connected to https://github.com/pulibrary/static-tables/issues/130