### PR TITLE
Avoid misleading autofill in browsers

### DIFF
--- a/app/components/PaginatedTable.test.js
+++ b/app/components/PaginatedTable.test.js
@@ -45,7 +45,7 @@ describe('PaginatedTable', () => {
     const [firstLabel, secondLabel, thirdLabel, fourthLabel] =
       wrapper.findAll('label');
     expect(firstLabel.text()).toEqual('Date');
-    expect(secondLabel.text()).toEqual('Name');
+    expect(secondLabel.text()).toEqual('Auction Name');
     expect(thirdLabel.text()).toEqual('Auction House');
     expect(fourthLabel.text()).toEqual('City');
   });
@@ -63,10 +63,11 @@ describe('PaginatedTable', () => {
     const [firstInput, secondInput] = wrapper.findAll('input');
 
     expect(firstInput.attributes('aria-label')).toBe('Date to filter by');
-    expect(firstInput.attributes('type')).toBe('text');
-    expect(secondInput.attributes('aria-label')).toBe('Name of auction');
-    expect(secondInput.attributes('type')).toBe('text');
-
+    expect(firstInput.attributes('type')).toBe('search');
+    expect(secondInput.attributes('aria-label')).toBe(
+      'Auction name for search'
+    );
+    expect(secondInput.attributes('type')).toBe('search');
     const [firstDropdown, secondDropdown] = wrapper.findAll('select');
 
     expect(firstDropdown.attributes('aria-label')).toBe(

--- a/app/components/TextFilter.js
+++ b/app/components/TextFilter.js
@@ -2,7 +2,7 @@ export default {
   name: 'TextFilter',
   template: `
       <label :for="config.id" class="form-label">{{ config.name }}</label>
-      <input class="form-control" :id="config.id" :aria-label="config.aria_label" type="text" @input="handleInput">
+      <input class="form-control" :id="config.id" :aria-label="config.aria_label" type="search" @input="handleInput">
       `,
   props: ['config'],
   emits: ['filterChange'],

--- a/app/configs/Marquand.js
+++ b/app/configs/Marquand.js
@@ -19,10 +19,10 @@ export default {
       data_column: 'Date'
     },
     {
-      id: 'name',
-      name: 'Name',
+      id: 'auction-name',
+      name: 'Auction Name',
       type: 'text',
-      aria_label: 'Name of auction',
+      aria_label: 'Auction name for search',
       data_column: 'Name'
     },
     {


### PR DESCRIPTION
- When you use "name" for a form field, browsers tend to try to fill it with the user's contact information, which is misleading for this form.
- Use input type="search" rather than text, per [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/searchbox_role#description)

Closes #113